### PR TITLE
Add no-eval eslint rule to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Other Style Guides
     ```
 
   <a name="strings--eval"></a><a name="6.5"></a>
-  - [6.4](#strings--eval) Never use `eval()` on a string, it opens too many vulnerabilities.
+  - [6.4](#strings--eval) Never use `eval()` on a string, it opens too many vulnerabilities. eslint: [`no-eval`](http://eslint.org/docs/rules/no-eval)
 
   <a name="strings--escaping"></a>
   - [6.5](#strings--escaping) Do not unnecessarily escape characters in strings. eslint: [`no-useless-escape`](http://eslint.org/docs/rules/no-useless-escape)

--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -55,7 +55,7 @@
     "eslint": "^3.19.0",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^7.0.1"
   },

--- a/packages/eslint-config-airbnb/rules/react-a11y.js
+++ b/packages/eslint-config-airbnb/rules/react-a11y.js
@@ -3,9 +3,13 @@ module.exports = {
     'jsx-a11y',
     'react'
   ],
-  ecmaFeatures: {
-    jsx: true
+
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
+
   rules: {
     // Enforce that anchors have content
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-has-content.md

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -2,13 +2,11 @@ module.exports = {
   plugins: [
     'react',
   ],
+
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
     },
-  },
-  ecmaFeatures: {
-    jsx: true,
   },
 
   // View link below for react rules documentation


### PR DESCRIPTION
Add a reference to the eslint `no-eval` rule to the README section 6.5.

This rule [is already set to `error`](https://github.com/airbnb/javascript/blob/75d48c7570b2c5336c75c454ce91991a34d0554e/packages/eslint-config-airbnb-base/rules/best-practices.js#L80) in best-practices.js in eslint-airbnb-config-base.